### PR TITLE
Windows fixes

### DIFF
--- a/Bar/python/CMakeLists.txt
+++ b/Bar/python/CMakeLists.txt
@@ -26,4 +26,8 @@ elseif(UNIX)
 		INSTALL_RPATH "$ORIGIN:$ORIGIN/../../${PROJECT_NAME}/.libs"
 		)
 endif()
-target_link_libraries(pyBar	PRIVATE	Bar)
+target_link_libraries(pyBar
+	PRIVATE
+	Bar
+	$<$<PLATFORM_ID:Windows>:${PYTHON_LIBRARIES}>
+	)

--- a/Foo/python/CMakeLists.txt
+++ b/Foo/python/CMakeLists.txt
@@ -27,4 +27,8 @@ elseif(UNIX)
     INSTALL_RPATH	"$ORIGIN:$ORIGIN/../../${PROJECT_NAME}/.libs"
 		)
 endif()
-target_link_libraries(pyFoo PRIVATE	Foo)
+target_link_libraries(pyFoo
+	PRIVATE
+	Foo
+	$<$<PLATFORM_ID:Windows>:${PYTHON_LIBRARIES}>
+	)

--- a/FooBar/python/CMakeLists.txt
+++ b/FooBar/python/CMakeLists.txt
@@ -24,4 +24,8 @@ elseif(UNIX)
 		INSTALL_RPATH "$ORIGIN:$ORIGIN/../../${PROJECT_NAME}/.libs"
 		)
 endif()
-target_link_libraries(pyFooBar PRIVATE FooBar)
+target_link_libraries(pyFooBar
+	PRIVATE
+	FooBar
+	$<$<PLATFORM_ID:Windows>:${PYTHON_LIBRARIES}>
+	)

--- a/cmake/python.cmake
+++ b/cmake/python.cmake
@@ -161,7 +161,7 @@ if(BUILD_TESTING)
 	# make a virtualenv to install our python package in it
 	add_custom_command(TARGET python_package POST_BUILD
 		COMMAND ${VENV_EXECUTABLE} -p ${PYTHON_EXECUTABLE} ${VENV_DIR}
-		COMMAND ${VENV_BIN} -m pip install "${CMAKE_CURRENT_BINARY_DIR}/python/dist/*.whl"
+		COMMAND ${VENV_BIN} -m pip install --find-links=./python/dist ${PROJECT_NAME}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 	# run the tests within the virtualenv
 	add_test(NAME pytest_venv COMMAND ${VENV_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/test.py)


### PR DESCRIPTION
These two commits fix issues with the Python build on Windows. The first commit undoes a [recent change](https://github.com/Mizux/cmake-swig/commit/ac4d5fffa7d27d32549c4aa0e79200e4fd2c4cc2) but only for the Windows builds. The second commit attempts to make the wheel install command cross platform as the original command does not work on Windows.